### PR TITLE
[JENKINS-69153] Do not call deprecated h.singletonList

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/emailext_template/ExtEmailTemplateManagement/sidepanel.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/emailext_template/ExtEmailTemplateManagement/sidepanel.groovy
@@ -35,5 +35,5 @@ l.side_panel() {
       l.task(icon:"icon-next icon-md", href:"${rootURL}/emailexttemplates", title:_("Editable Email Templates"))
       l.task(icon:"icon-new-package icon-md", href:"addTemplate", title:_("Add New Template"))
     }
-    t.executors(computers:h.singletonList(it))
+    t.executors(computers:it)
 }

--- a/src/main/resources/org/jenkinsci/plugins/emailext_template/ExtEmailTemplateManagement/sidepanel.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/emailext_template/ExtEmailTemplateManagement/sidepanel.groovy
@@ -35,5 +35,5 @@ l.side_panel() {
       l.task(icon:"icon-next icon-md", href:"${rootURL}/emailexttemplates", title:_("Editable Email Templates"))
       l.task(icon:"icon-new-package icon-md", href:"addTemplate", title:_("Add New Template"))
     }
-    t.executors(computers:it)
+    t.executors(computers: [it])
 }


### PR DESCRIPTION
## [JENKINS-69153](https://issues.jenkins.io/browse/JENKINS-69153) Do not call deprecated h.singletonList

Jenkins 2.358 deprecated the `Functions.singletonList` method because it is not normally needed in JEXL.  The `h.singletonList(it)` call in this groovy code reports a null pointer exception in Jenkins 2.358 and later.

When the `h.singletonList(it)` call is replaced with `it`, the null pointer exception is not reported and the page loads.

Needs more testing from people that are experienced with email extension template plugin.

Would benefit from a round trip test that checks the page loads.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

