### PR TITLE
Use https: instead of git: in SCM url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
   </repositories>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>


### PR DESCRIPTION
## Use https:// instead of git:// protocol in pom.xml

GitHub has deprecated the git:// protocol and no longer answers requests over that protocol

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
