### PR TITLE
Remove artifact caching proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,6 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Opt-in to the Artifact Caching Proxy, to be removed when it will be in opt-out.
-  // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
-  artifactCachingProxyEnabled: true,
   // Test Java 8 with default Jenkins version, Java 11 with a recent LTS, Java 17 even more recent
   configurations: [
     [platform: 'linux',   jdk: '17', jenkins: '2.375'],


### PR DESCRIPTION
The artifact caching proxy failed the build of #90 .  Since this repository is not one of the repositories that receive lots of attention, let's remove that experimental feature and only use it on repositories that get more regular attention.